### PR TITLE
Improve support email formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ These SDKs are available separately and provide a convenient, language-specific 
 
 ## Contributing
 
-Functional changes to the protobuf definitions are not accepted at this time, as these files are maintained by xAI to ensure compatibility with our API services. However, changes to improve documentation, fix typos, etc., are welcome. If you have feedback or suggestions, please contact xAI through the [official API support channels](mailto:support@x.ai).
+Functional changes to the protobuf definitions are not accepted at this time, as these files are maintained by xAI to ensure compatibility with our API services. However, changes to improve documentation, fix typos, etc., are welcome. If you have feedback or suggestions, please contact xAI through the official API support channels [support@x.ai](mailto:support@x.ai).
 
 Please see the [contributing documentation](./CONTRIBUTING.md) for full details on contributing to this repository.
 


### PR DESCRIPTION
This PR addresses an accessibility and usability enhancement in the README.md file for the xai-proto repository. Specifically, it converts the reference to the support email in the Contributing section.

### Motivation
This change makes the email address to be read by accessibility tools and users to know they will be clicking an email mailto in rendered Markdown views (e.g., on GitHub), enhancing the developer experience while preserving the original wording and intent. No functional or breaking changes are introduced.

As noted in the repository's improvement suggestions, hyperlinking the email improves navigation and accessibility for contributors.

### Testing
Verified the link renders correctly on GitHub. Ensured no other parts of the README are affected.

