### PR TITLE
Add cost_usd_ticks to usage.proto

### DIFF
--- a/proto/xai/api/v1/usage.proto
+++ b/proto/xai/api/v1/usage.proto
@@ -29,12 +29,18 @@ message SamplingUsage {
 
   // Number of individual live search sources used.
   // Only applicable when live search is enabled.
-  // e.g. If a live search query returns citations from both X and Web and news sources, this will be 3.
-  // If it returns citations from only X, this will be 1.
+  // e.g. If a live search query returns citations from both X and Web and news
+  // sources, this will be 3. If it returns citations from only X, this will
+  // be 1.
   int32 num_sources_used = 8;
 
   // List of server side tools called.
   repeated ServerSideTool server_side_tools_used = 9;
+
+  // Accurate cost of this request, denominated in "USD ticks".
+  // 1 USD = 10,000,000,000 ticks (i.e. 1 tick = 1e-10 USD).
+  // To convert to dollars, divide by 10,000,000,000.
+  optional int64 cost_in_usd_ticks = 11;
 }
 
 // Usage of embedding models.

--- a/proto/xai/api/v1/usage.proto
+++ b/proto/xai/api/v1/usage.proto
@@ -27,17 +27,19 @@ message SamplingUsage {
   // Total number of image tokens in the prompt.
   int32 prompt_image_tokens = 5;
 
-  // Number of individual live search sources used.
-  // Only applicable when live search is enabled.
-  // e.g. If a live search query returns citations from both X and Web and news
-  // sources, this will be 3. If it returns citations from only X, this will
-  // be 1.
+  // [DEPRECATED - live search feature has been deprecated so this field is
+  // redundant] Number of individual live search sources used. Only applicable
+  // when live search is enabled. e.g. If a live search query returns citations
+  // from both X and Web and news sources, this will be 3. If it returns
+  // citations from only X, this will be 1.
   int32 num_sources_used = 8;
 
   // List of server side tools called.
   repeated ServerSideTool server_side_tools_used = 9;
 
-  // Accurate cost of this request, denominated in "USD ticks".
+  // Full price paid by the user for this request, in USD ticks.
+  // For requests with server-side tools, this is the sum of token cost and
+  // server-side tool cost. Also used for image gen, video gen, etc.
   // 1 USD = 10,000,000,000 ticks (i.e. 1 tick = 1e-10 USD).
   // To convert to dollars, divide by 10,000,000,000.
   optional int64 cost_in_usd_ticks = 11;


### PR DESCRIPTION
Adds cost information to usage.proto allowing other responses that reference this message such as VideoResponse to have cost information for a given request.