### PR TITLE
Add Go bindings support

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -26,4 +26,13 @@ plugins:
     opt:
       - target=ts
       - json_types=true
-  
+
+  # go
+  - remote: buf.build/protocolbuffers/go:v1.36.6
+    out: gen/go
+    opt:
+      - module=github.com/xai-org/xai-proto/gen/go
+  - remote: buf.build/grpc/go:v1.5.1
+    out: gen/go
+    opt:
+      - module=github.com/xai-org/xai-proto/gen/go

--- a/proto/xai/api/v1/auth.proto
+++ b/proto/xai/api/v1/auth.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 

--- a/proto/xai/api/v1/batch.proto
+++ b/proto/xai/api/v1/batch.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";

--- a/proto/xai/api/v1/chat.proto
+++ b/proto/xai/api/v1/chat.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 import "google/protobuf/timestamp.proto";
 import "xai/api/v1/deferred.proto";
 import "xai/api/v1/documents.proto";

--- a/proto/xai/api/v1/collections.proto
+++ b/proto/xai/api/v1/collections.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package collections;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1/collections;collectionspb";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 

--- a/proto/xai/api/v1/deferred.proto
+++ b/proto/xai/api/v1/deferred.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 // The response from the service, when creating a deferred completion request.
 message StartDeferredResponse {
   // The ID of this request. This ID can be used to retrieve completion results

--- a/proto/xai/api/v1/documents.proto
+++ b/proto/xai/api/v1/documents.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 service Documents {
   rpc Search(SearchRequest) returns (SearchResponse) {}
 }

--- a/proto/xai/api/v1/embed.proto
+++ b/proto/xai/api/v1/embed.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 import "xai/api/v1/image.proto";
 import "xai/api/v1/usage.proto";
 

--- a/proto/xai/api/v1/files.proto
+++ b/proto/xai/api/v1/files.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 import "google/protobuf/timestamp.proto";
 
 // Service for uploading, listing, retrieving, and deleting files.

--- a/proto/xai/api/v1/image.proto
+++ b/proto/xai/api/v1/image.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 import "xai/api/v1/usage.proto";
 
 // An API service for interaction with image generation models.

--- a/proto/xai/api/v1/models.proto
+++ b/proto/xai/api/v1/models.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 

--- a/proto/xai/api/v1/sample.proto
+++ b/proto/xai/api/v1/sample.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 import "google/protobuf/timestamp.proto";
 import "xai/api/v1/usage.proto";
 

--- a/proto/xai/api/v1/tokenize.proto
+++ b/proto/xai/api/v1/tokenize.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 // An API service to tokenize input prompts.
 service Tokenize {
   // Convert text to a sequence of tokens.

--- a/proto/xai/api/v1/usage.proto
+++ b/proto/xai/api/v1/usage.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 // Records the cost associated with a sampling request (both chat and sample
 // endpoints).
 message SamplingUsage {

--- a/proto/xai/api/v1/video.proto
+++ b/proto/xai/api/v1/video.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xai_api;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/api/v1;xaiapipb";
+
 import "xai/api/v1/deferred.proto";
 import "xai/api/v1/image.proto";
 import "xai/api/v1/usage.proto";

--- a/proto/xai/management_api/v1/billing.proto
+++ b/proto/xai/management_api/v1/billing.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package prod_mc_billing;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/management_api/v1;managementapipb";
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 import "xai/shared/analytics/analytics.proto";

--- a/proto/xai/shared/analytics/analytics.proto
+++ b/proto/xai/shared/analytics/analytics.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package prod.clickhouse_analytics;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/shared/analytics;analyticspb";
+
 import "google/protobuf/timestamp.proto";
 
 // Time series are created by aggregating value into buckets we call `TimeUnit`.

--- a/proto/xai/shared/billing/types.proto
+++ b/proto/xai/shared/billing/types.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package prod_charger;
 
+option go_package = "github.com/xai-org/xai-proto/gen/go/xai/shared/billing;billingpb";
+
 // =====================================================================================================================
 // Cent
 


### PR DESCRIPTION
## Summary

Sets `option go_package` on every `.proto` file and adds Go plugins to `buf.gen.yaml`. After this change, anyone who runs `buf generate` against this repo (locally or against the GitHub ref) gets a working multi-package Go layout out of the box — no managed-mode `go_package_prefix` or per-file `disable` blocks needed.

Stacks on [#51](https://github.com/xai-org/xai-proto/pull/51) (which adds the new `collections`/`shared`/`rag` proto packages that motivate per-file `go_package` in the first place).

## Generated layout

| Proto package | Go directory | Go alias |
|---|---|---|
| `xai_api` (13 files) | `gen/go/xai/api/v1/` | `xaiapipb` |
| `collections` | `gen/go/xai/api/v1/collections/` | `collectionspb` |
| `shared` | `gen/go/xai/api/v1/shared/` | `sharedpb` |
| `rag` | `gen/go/xai/api/v1/rag/` | `ragpb` |
| `prod_mc_billing` | `gen/go/xai/management_api/v1/` | `managementapipb` |
| `prod.clickhouse_analytics` | `gen/go/xai/shared/analytics/` | `analyticspb` |
| `prod_charger` | `gen/go/xai/shared/billing/` | `billingpb` |

Each proto package gets its own Go directory and Go package alias, so the four packages in `xai/api/v1/` (`xai_api`, `collections`, `shared`, `rag`) don't collide. The `module=` opt on the Go plugins strips the module prefix from output paths so files land at `gen/go/<dir>/<file>.pb.go` matching the import paths declared in each file's `go_package`.

## Why `option go_package` on every file

`protoc-gen-go` requires a Go import path to be set somehow — via per-file `option go_package`, managed-mode `go_package_prefix`, or per-file `M` flags. Setting `option go_package` per file is the path Google takes (`googleapis`, `protocolbuffers/protobuf`) and means consumers don't have to author any managed-mode config to get working generation.

A consumer's gen config can be as minimal as:

```yaml
version: v2
plugins:
  - remote: buf.build/protocolbuffers/go:v1.36.6
    out: gen/go
    opt: module=github.com/xai-org/xai-proto/gen/go
  - remote: buf.build/grpc/go:v1.5.1
    out: gen/go
    opt: module=github.com/xai-org/xai-proto/gen/go
```

Then `buf generate https://github.com/xai-org/xai-proto.git` produces a tree they can drop into their project (with a `go.mod replace` until xai-proto publishes Go).

## Publishing

This PR does **not** commit `gen/` or publish Go anywhere — `gen/` remains gitignored, same as Python and TS today. The generated Go is regenerated locally on demand. The `option go_package` URLs (`github.com/xai-org/xai-proto/gen/go/...`) are forward-looking defaults: if/when xai-proto starts shipping Go, those import paths will resolve via `go get`. Until then, consumers use `replace` in their `go.mod`.

## Verification

- `buf lint` clean
- `buf breaking --against '.git#branch=main'` clean (additive)
- `buf generate` produces all 7 Go packages without error
- `cd gen/go && go mod init github.com/xai-org/xai-proto/gen/go && go mod tidy && go build ./...` succeeds
- Python regen still produces wire-equivalent output (the new `go_package` only affects `FileOptions` metadata, not message wire format) — `xai-sdk-python` 603/603 tests pass after regen