### PR TITLE
Add missing batch.proto fields

### DIFF
--- a/proto/xai/api/v1/batch.proto
+++ b/proto/xai/api/v1/batch.proto
@@ -67,6 +67,10 @@ message Batch {
 
   // Cost breakdown for processed requests.
   BatchCostBreakdown cost_breakdown = 9;
+
+  // File ID of the uploaded JSONL input file (from Files API). Only set
+  // when the batch was created via file upload.
+  optional string input_file_id = 10;
 }
 
 // Holds aggregate information about the current state of a batch process.
@@ -194,6 +198,10 @@ message BatchRequestMetadata {
 message CreateBatchRequest {
   // The name of the batch to be created.
   string name = 1;
+
+  // Optional file ID of a JSONL input file (uploaded via the Files API).
+  // When provided, the batch will be populated from the file's contents.
+  string input_file_id = 2;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -260,6 +268,9 @@ message ListBatchRequestMetadataRequest {
 
   // Optional pagination token to retrieve a specific page. Provided by `pagination_token` in `ListBatchRequestMetadataResponse`.
   optional string pagination_token = 3;
+
+  // Optional filter by request state. If empty, all states are returned.
+  repeated BatchRequestMetadata.State status = 4;
 }
 
 // Response with the metadata of batch requests within a batch.


### PR DESCRIPTION
## Summary

Adds three fields to `batch.proto` that ship in the published Python SDK but were never declared here.

| Field | Where | Status before this PR |
|---|---|---|
| `Batch.input_file_id` (optional string, field 10) | `Batch` message | absent in xai-proto, present in SDK |
| `CreateBatchRequest.input_file_id` (string, field 2) | `CreateBatchRequest` | same |
| `ListBatchRequestMetadataRequest.status` (repeated `BatchRequestMetadata.State`, field 4) | filter param on metadata listing | same |

## Import order

Keeps xai-proto's existing convention — alphabetical by full import path (`google.protobuf.*` → `google.rpc.*` → `xai/api/v1/*`). Matches every other file in `proto/xai/api/v1/` and keeps the `google.protobuf.*` imports adjacent in the generated Python.

## Wire compatibility

- Existing fields and field numbers unchanged → all current clients keep working byte-for-byte
- New fields are additive (proto3 default behavior: unknown fields are tolerated on decode, omitted fields encode as zero bytes)
- gRPC method paths unchanged

## Effect on [xai-org/xai-sdk-python#141](https://github.com/xai-org/xai-sdk-python/pull/141)

After this lands, that PR can regen cleanly from xai-proto and the diff will collapse to just the actual feature additions (`video_extension_request` field + `prepare_extension()` method + tests + CHANGELOG).