### PR TITLE
fix: use optional bool for safe_search to preserve documented default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ gen/
 .idea/
 .vscode/
 .DS_Store
+*.pyc
+__pycache__/
+*_pb2.py
+*_pb2_grpc.py
+.venv/

--- a/proto/xai/api/v1/chat.proto
+++ b/proto/xai/api/v1/chat.proto
@@ -947,8 +947,9 @@ message WebSource {
   // See https://en.wikipedia.org/wiki/ISO_3166-2 for valid codes.
   optional string country = 3;
 
-  // Whether to exclude adult content from the search results. Defaults to true.
-  bool safe_search = 4;
+  // Whether to exclude adult content from the search results.
+  // When unset, defaults to true (adult content is excluded).
+  optional bool safe_search = 4;
 }
 
 // Configuration for a news search source in search requests.
@@ -966,8 +967,9 @@ message NewsSource {
   // See https://en.wikipedia.org/wiki/ISO_3166-2 for valid codes.
   optional string country = 3;
 
-  // Whether to exclude adult content from the search results. Defaults to true.
-  bool safe_search = 4;
+  // Whether to exclude adult content from the search results.
+  // When unset, defaults to true (adult content is excluded).
+  optional bool safe_search = 4;
 }
 
 // Configuration for an X (formerly Twitter) search source in search requests.

--- a/tests/safe_search_default.proto
+++ b/tests/safe_search_default.proto
@@ -1,0 +1,20 @@
+// Minimal reproduction of the safe_search default value issue.
+// Demonstrates the difference between bool (no presence tracking)
+// and optional bool (with presence tracking) in proto3.
+syntax = "proto3";
+
+package test;
+
+// Simulates the BEFORE state: plain bool field.
+// Proto3 bool defaults to false — server cannot distinguish
+// "client didn't set it" from "client explicitly set false".
+message WebSourceBefore {
+  bool safe_search = 1;
+}
+
+// Simulates the AFTER state: optional bool field.
+// Server can call HasField() to detect whether the client set the value,
+// and apply its own default (true) when unset.
+message WebSourceAfter {
+  optional bool safe_search = 1;
+}

--- a/tests/test_safe_search_default.py
+++ b/tests/test_safe_search_default.py
@@ -1,0 +1,108 @@
+"""
+Test: proto3 bool vs optional bool default behavior for safe_search.
+
+Demonstrates that a plain `bool` field cannot distinguish "unset" from
+"explicitly set to false", while `optional bool` can — allowing the
+server to apply the documented default of true when the field is unset.
+"""
+
+import safe_search_default_pb2 as pb
+
+
+class TestBoolDefaultMismatch:
+    """Tests showing the bug: plain bool loses the 'unset' signal."""
+
+    def test_plain_bool_defaults_to_false(self):
+        """A plain bool field defaults to false in proto3."""
+        msg = pb.WebSourceBefore()
+        assert msg.safe_search is False, (
+            "Proto3 bool defaults to false, contradicting the documented default of true"
+        )
+
+    def test_plain_bool_cannot_detect_unset(self):
+        """The server cannot tell 'unset' apart from 'explicitly false'."""
+        unset = pb.WebSourceBefore()  # Client didn't set safe_search
+        explicit_false = pb.WebSourceBefore(safe_search=False)  # Client wants adult content
+
+        # These serialize to identical bytes — the server sees no difference
+        assert unset.SerializeToString() == explicit_false.SerializeToString(), (
+            "Unset and explicitly-false produce identical wire representations"
+        )
+
+    def test_plain_bool_has_no_presence_tracking(self):
+        """HasField raises ValueError for plain bool — presence is not tracked."""
+        import pytest
+
+        msg = pb.WebSourceBefore()
+        with pytest.raises(ValueError, match="does not have presence"):
+            msg.HasField("safe_search")
+
+
+class TestOptionalBoolFix:
+    """Tests showing the fix: optional bool preserves the 'unset' signal."""
+
+    def test_optional_bool_detects_unset(self):
+        """Server can detect when the client didn't set the field."""
+        msg = pb.WebSourceAfter()
+        assert not msg.HasField("safe_search"), (
+            "HasField returns False when the client never set safe_search"
+        )
+
+    def test_optional_bool_detects_explicit_false(self):
+        """Server can detect when the client explicitly set false."""
+        msg = pb.WebSourceAfter(safe_search=False)
+        assert msg.HasField("safe_search"), (
+            "HasField returns True when the client explicitly set safe_search=False"
+        )
+
+    def test_optional_bool_detects_explicit_true(self):
+        """Server can detect when the client explicitly set true."""
+        msg = pb.WebSourceAfter(safe_search=True)
+        assert msg.HasField("safe_search")
+        assert msg.safe_search is True
+
+    def test_unset_and_false_have_different_wire_bytes(self):
+        """Unlike plain bool, optional bool distinguishes the two on the wire."""
+        unset = pb.WebSourceAfter()
+        explicit_false = pb.WebSourceAfter(safe_search=False)
+
+        # With optional, explicitly setting false IS encoded on the wire
+        assert unset.SerializeToString() != explicit_false.SerializeToString(), (
+            "optional bool encodes explicit false differently from unset"
+        )
+
+    def test_server_can_apply_documented_default(self):
+        """The server can now implement the documented 'defaults to true' behavior."""
+        def apply_server_default(request: pb.WebSourceAfter) -> bool:
+            if request.HasField("safe_search"):
+                return request.safe_search  # Honor explicit client choice
+            return True  # Apply documented default
+
+        assert apply_server_default(pb.WebSourceAfter()) is True, (
+            "Unset → server applies default true (safe search ON)"
+        )
+        assert apply_server_default(pb.WebSourceAfter(safe_search=False)) is False, (
+            "Explicit false → server honors client choice (safe search OFF)"
+        )
+        assert apply_server_default(pb.WebSourceAfter(safe_search=True)) is True, (
+            "Explicit true → server honors client choice (safe search ON)"
+        )
+
+    def test_roundtrip_preserves_unset(self):
+        """The 'unset' signal survives serialization and deserialization."""
+        wire = pb.WebSourceAfter().SerializeToString()
+        received = pb.WebSourceAfter()
+        received.ParseFromString(wire)
+        assert not received.HasField("safe_search"), (
+            "Unset survives the wire roundtrip"
+        )
+
+    def test_roundtrip_preserves_explicit_false(self):
+        """An explicit false survives serialization and deserialization."""
+        wire = pb.WebSourceAfter(safe_search=False).SerializeToString()
+        received = pb.WebSourceAfter()
+        received.ParseFromString(wire)
+        assert received.HasField("safe_search"), (
+            "Explicit false survives the wire roundtrip"
+        )
+        assert received.safe_search is False


### PR DESCRIPTION
## Summary

- `WebSource.safe_search` and `NewsSource.safe_search` are documented as "Defaults to true", but proto3 `bool` defaults to `false` on the wire
- Clients omitting the field silently receive unfiltered adult content, contradicting the API documentation
- Changes both fields from `bool` to `optional bool`, allowing the server to distinguish "unset" (apply default `true`) from "explicitly set to `false`"

## Problem

In proto3, a plain `bool` field has **no presence tracking**. The server receives `false` in both cases:

| Client intent | Wire value | Server sees |
|---|---|---|
| Didn't set `safe_search` (expects documented default `true`) | `false` | `false` |
| Explicitly set `safe_search = false` (wants adult content) | `false` | `false` |

The server cannot distinguish these two cases. Every client trusting the documentation gets unfiltered results.

## Fix

`optional bool` adds presence tracking. The server can now call `HasField("safe_search")`:
- **Unset** → `HasField` returns `false` → server applies documented default (`true`)
- **Explicitly `false`** → `HasField` returns `true`, value is `false` → server honors client choice
- **Explicitly `true`** → `HasField` returns `true`, value is `true` → server honors client choice

## Wire compatibility

This change is **backward compatible**. The `optional` keyword in proto3 does not change the field number or wire encoding — it only adds presence tracking in generated code. Existing clients continue to work unchanged.

## Test plan

- [x] 10 pytest cases added (`tests/test_safe_search_default.py`) proving:
  - Plain `bool`: unset and explicit `false` serialize to identical bytes; `HasField()` raises `ValueError`
  - `optional bool`: unset and explicit `false` serialize differently; `HasField()` works; roundtrip preserves intent
- [ ] Verify `buf lint` and `buf breaking` pass
- [ ] Verify server-side default logic applies `true` when field is unset

---
Continuous collaboration, powered by [ClosedLoop.AI](https://closedloop.ai) | [GitHub](https://github.com/ClosedLoop-AI)