### PR TITLE
fix: use optional bool for return_citations to match documented default

### DIFF
--- a/proto/xai/api/v1/chat.proto
+++ b/proto/xai/api/v1/chat.proto
@@ -892,8 +892,9 @@ message SearchParameters {
   google.protobuf.Timestamp to_date = 5;
 
   // If set to true, the model will return a list of citations (URLs or references)
-  // to the sources used in generating the response. Defaults to true.
-  bool return_citations = 7;
+  // to the sources used in generating the response.
+  // When unset, defaults to true (citations are returned).
+  optional bool return_citations = 7;
 
   // Optional limit on the number of search results to consider
   // when generating a response. Must be in the range [1, 30]. Defaults to 15.


### PR DESCRIPTION
## Summary

- `SearchParameters.return_citations` is documented as "Defaults to true", but proto3 `bool` defaults to `false` on the wire
- Clients omitting the field silently lose citations in search responses, contradicting the API docs
- Changes the field from `bool` to `optional bool` so the server can distinguish "unset" from "explicitly false"

## Problem

Same class of bug as `safe_search` (see #56). Proto3 `bool` has no presence tracking — the server receives `false` for both "client didn't set it" and "client explicitly set false". Clients trusting the documented default of `true` get no citations.

## Fix

`optional bool` adds `HasField()` support:
- **Unset** → server applies documented default (`true`, citations returned)
- **Explicitly `false`** → server honors client choice (no citations)

## Wire compatibility

Backward compatible. `optional` does not change field number or wire encoding — only adds presence tracking in generated code.

## Test plan

- [ ] Verify `buf lint` and `buf breaking` pass
- [ ] Verify server applies `true` default when field is unset
- [x] Underlying proto3 `bool` vs `optional bool` behavior validated by tests in #56

---
Continuous collaboration, powered by [ClosedLoop.AI](https://closedloop.ai) | [GitHub](https://github.com/ClosedLoop-AI)