### PR TITLE
fix: deprecate singular image field, unify on images list

### DIFF
--- a/proto/xai/api/v1/image.proto
+++ b/proto/xai/api/v1/image.proto
@@ -17,8 +17,11 @@ message GenerateImageRequest {
   // Input prompt to generate an image from.
   string prompt = 1;
 
-  // Optional input image to perform generations based on.
-  ImageUrlContent image = 5;
+  // Deprecated: Use `images` instead. For single-image input, pass a
+  // one-element `images` list. This field and `images` are mutually
+  // exclusive but proto3 cannot enforce that constraint — setting both
+  // produces undefined behavior.
+  ImageUrlContent image = 5 [deprecated = true];
 
   // Name or alias of the image generation model to be used.
   string model = 2;
@@ -49,9 +52,10 @@ message GenerateImageRequest {
   // adjusted to preserve aspect ratio and rounded to multiples of 16.
   optional ImageResolution resolution = 15;
 
-  // Optional list of input images for multi-reference image editing.
-  // Each image is either an image URL or a base64-encoded version of the image.
-  // This field cannot be set together with the `image` field.
+  // Optional input image(s) for image editing or multi-reference generation.
+  // Each element is either an image URL or a base64-encoded image.
+  // For single-image editing, pass a one-element list.
+  // Replaces the deprecated `image` field — do not set both.
   repeated ImageUrlContent images = 17;
 }
 

--- a/tests/image_deprecation.proto
+++ b/tests/image_deprecation.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package test;
+
+message ImageUrl {
+  string url = 1;
+}
+
+// Before: both fields exist, no deprecation, mutual exclusivity only in comments
+message GenerateImageRequestBefore {
+  ImageUrl image = 5;
+  repeated ImageUrl images = 17;
+}
+
+// After: singular field deprecated, clients should use images list
+message GenerateImageRequestAfter {
+  ImageUrl image = 5 [deprecated = true];
+  repeated ImageUrl images = 17;
+}

--- a/tests/test_image_deprecation.py
+++ b/tests/test_image_deprecation.py
@@ -1,0 +1,141 @@
+"""Tests demonstrating the image field deprecation fix.
+
+Bug: The singular `image` field (field 5) and the repeated `images` field (field 17)
+in GenerateImageRequest are documented as mutually exclusive, but proto3 cannot
+enforce mutual exclusivity between a singular and repeated field (repeated fields
+cannot participate in a oneof).
+
+Fix: Deprecate the singular `image` field so clients are steered toward `images`,
+which is a strict superset (supports 0, 1, or many elements).
+"""
+
+from image_deprecation_pb2 import (
+    GenerateImageRequestAfter,
+    GenerateImageRequestBefore,
+    ImageUrl,
+)
+
+
+# ---------------------------------------------------------------------------
+# Bug tests (Before) -- demonstrate the ambiguity problem
+# ---------------------------------------------------------------------------
+
+
+class TestBugBeforeFix:
+    """Tests on GenerateImageRequestBefore showing the mutual-exclusivity gap."""
+
+    def test_both_image_and_images_can_be_set_simultaneously(self):
+        """Both `image` and `images` can be populated at the same time --
+        proto3 raises no error, which is the root of the ambiguity."""
+        msg = GenerateImageRequestBefore()
+        msg.image.CopyFrom(ImageUrl(url="https://example.com/single.png"))
+        msg.images.append(ImageUrl(url="https://example.com/list1.png"))
+        msg.images.append(ImageUrl(url="https://example.com/list2.png"))
+
+        # No exception was raised -- both fields coexist happily
+        assert msg.image.url == "https://example.com/single.png"
+        assert len(msg.images) == 2
+
+    def test_round_trip_preserves_both_fields(self):
+        """Serialization round-trip keeps BOTH fields, proving ambiguity
+        survives the wire."""
+        msg = GenerateImageRequestBefore()
+        msg.image.CopyFrom(ImageUrl(url="https://example.com/single.png"))
+        msg.images.append(ImageUrl(url="https://example.com/list1.png"))
+
+        wire = msg.SerializeToString()
+        restored = GenerateImageRequestBefore()
+        restored.ParseFromString(wire)
+
+        # Both fields survived the round-trip
+        assert restored.image.url == "https://example.com/single.png"
+        assert len(restored.images) == 1
+        assert restored.images[0].url == "https://example.com/list1.png"
+
+    def test_server_cannot_distinguish_intent(self):
+        """A server receiving a message with both fields set has no
+        proto-level mechanism to determine which one the client intended."""
+        msg = GenerateImageRequestBefore()
+        msg.image.CopyFrom(ImageUrl(url="https://example.com/primary.png"))
+        msg.images.append(ImageUrl(url="https://example.com/alt.png"))
+
+        # The descriptor has no oneof containing these fields
+        descriptor = GenerateImageRequestBefore.DESCRIPTOR
+        image_field = descriptor.fields_by_name["image"]
+        images_field = descriptor.fields_by_name["images"]
+
+        # Neither field belongs to a oneof -- no built-in mutual exclusivity
+        assert image_field.containing_oneof is None
+        assert images_field.containing_oneof is None
+
+        # Both fields report as set, so the server must guess
+        assert msg.HasField("image")
+        assert len(msg.images) > 0
+
+
+# ---------------------------------------------------------------------------
+# Fix tests (After) -- the deprecated annotation steers clients to `images`
+# ---------------------------------------------------------------------------
+
+
+class TestFixAfter:
+    """Tests on GenerateImageRequestAfter showing the deprecation approach."""
+
+    def test_image_field_is_marked_deprecated(self):
+        """The `image` field descriptor carries the deprecated option."""
+        descriptor = GenerateImageRequestAfter.DESCRIPTOR
+        image_field = descriptor.fields_by_name["image"]
+        assert image_field.GetOptions().deprecated is True
+
+    def test_images_field_is_not_deprecated(self):
+        """The `images` field remains current -- it is the replacement."""
+        descriptor = GenerateImageRequestAfter.DESCRIPTOR
+        images_field = descriptor.fields_by_name["images"]
+        assert images_field.GetOptions().deprecated is False
+
+    def test_single_element_images_is_equivalent_to_old_image(self):
+        """`images` with one element carries the same data as the old
+        singular `image` field."""
+        old_msg = GenerateImageRequestAfter()
+        old_msg.image.CopyFrom(ImageUrl(url="https://example.com/photo.png"))
+
+        new_msg = GenerateImageRequestAfter()
+        new_msg.images.append(ImageUrl(url="https://example.com/photo.png"))
+
+        # The payload in images[0] is identical to what was in image
+        assert new_msg.images[0].url == old_msg.image.url
+
+    def test_images_supports_zero_elements(self):
+        """`images` can be empty, representing 'no image provided'."""
+        msg = GenerateImageRequestAfter()
+        assert len(msg.images) == 0
+
+    def test_images_supports_one_element(self):
+        """`images` with one element replaces the old singular field."""
+        msg = GenerateImageRequestAfter()
+        msg.images.append(ImageUrl(url="https://example.com/one.png"))
+        assert len(msg.images) == 1
+        assert msg.images[0].url == "https://example.com/one.png"
+
+    def test_images_supports_many_elements(self):
+        """`images` can hold multiple elements -- a superset of singular."""
+        msg = GenerateImageRequestAfter()
+        for i in range(5):
+            msg.images.append(ImageUrl(url=f"https://example.com/{i}.png"))
+        assert len(msg.images) == 5
+
+    def test_migration_path_image_to_images(self):
+        """Data from the old `image` field can be migrated to `images[0]`."""
+        # Simulate a legacy message that only set the singular field
+        legacy = GenerateImageRequestAfter()
+        legacy.image.CopyFrom(ImageUrl(url="https://example.com/legacy.png"))
+
+        # Migration: copy singular into the repeated list
+        migrated = GenerateImageRequestAfter()
+        if legacy.HasField("image"):
+            migrated.images.append(ImageUrl(url=legacy.image.url))
+
+        # The migrated message uses only the non-deprecated field
+        assert len(migrated.images) == 1
+        assert migrated.images[0].url == "https://example.com/legacy.png"
+        assert not migrated.HasField("image")  # singular field untouched


### PR DESCRIPTION
## Summary

- `GenerateImageRequest` has both `image` (field 5, singular) and `images` (field 17, repeated) that are documented as mutually exclusive
- Proto3 cannot enforce this constraint — `repeated` fields cannot be placed in a `oneof`
- Setting both fields produces undefined server behavior
- Deprecates `image` in favor of `images` (a superset: supports 0, 1, or many images)

## Problem

```protobuf
message GenerateImageRequest {
  ImageUrlContent image = 5;            // single image
  // ...
  // "This field cannot be set together with the `image` field."
  repeated ImageUrlContent images = 17; // multiple images
}
```

The mutual exclusivity is only documented in a comment. Nothing prevents a client from setting both fields. When both are set:
- Which image does the model use as its reference? `image`? First element of `images`? All of them?
- Does the server error, silently ignore one, or produce unpredictable output?

At scale, some percentage of requests **will** set both (SDK bugs, migration confusion, copy-paste errors), leading to undefined model behavior.

## Fix

Deprecate the singular `image` field with `[deprecated = true]` and update documentation to direct clients to `images`:

- **Single-image editing**: pass a one-element `images` list
- **Multi-reference editing**: pass multiple elements in `images`
- **No image input**: leave `images` empty

This gives clients a single canonical field, eliminates the ambiguity, and generated code will emit deprecation warnings for `image` usage.

## Wire compatibility

Fully backward compatible. The `[deprecated = true]` annotation does not change wire encoding — it only triggers warnings in generated client code. The `image` field remains readable for existing clients during the migration period.

## Test plan

- [ ] Verify `buf lint` and `buf breaking` pass
- [ ] Verify generated Python/TypeScript code emits deprecation warning for `image`
- [ ] Verify server treats `images` with one element identically to the old `image` field
- [ ] Update SDK examples and documentation to use `images`

---
Continuous collaboration, powered by [ClosedLoop.AI](https://closedloop.ai) | [GitHub](https://github.com/ClosedLoop-AI)