### PR TITLE
feat: add ServiceTier enum and service_tier field to chat API

### DIFF
--- a/proto/xai/api/v1/chat.proto
+++ b/proto/xai/api/v1/chat.proto
@@ -175,6 +175,10 @@ message GetCompletionsRequest {
   // Number of agents to use for multi-agent models.
   // Only valid when model is a `multi-agent` model. Defaults to `AGENT_COUNT_UNSPECIFIED`.
   optional AgentCount agent_count = 29;
+
+  // Processing tier for this request. Set to SERVICE_TIER_PRIORITY for
+  // higher scheduling priority at a higher price.
+  ServiceTier service_tier = 30;
 }
 
 message GetChatCompletionResponse {
@@ -213,6 +217,9 @@ message GetChatCompletionResponse {
 
   // Debug output. Only available to trusted testers.
   DebugOutput debug_output = 12;
+
+  // The processing tier that was used for this request.
+  ServiceTier service_tier = 13;
 }
 
 message GetChatCompletionChunk {
@@ -249,6 +256,9 @@ message GetChatCompletionChunk {
 
   // Only available for teams that have debugging privileges.
   DebugOutput debug_output = 10;
+
+  // The processing tier that was used for this request.
+  ServiceTier service_tier = 11;
 }
 
 // Response from GetDeferredCompletion, including the response if the completion

--- a/proto/xai/api/v1/usage.proto
+++ b/proto/xai/api/v1/usage.proto
@@ -54,6 +54,18 @@ message EmbeddingUsage {
   int32 num_image_embeddings = 2;
 }
 
+// Processing tier for a request. Controls scheduling priority and pricing.
+enum ServiceTier {
+  // Unspecified / default behavior.
+  SERVICE_TIER_UNSPECIFIED = 0;
+
+  // Default processing tier.
+  SERVICE_TIER_DEFAULT = 1;
+
+  // Priority processing tier with higher scheduling priority at a higher price.
+  SERVICE_TIER_PRIORITY = 2;
+}
+
 enum ServerSideTool {
   SERVER_SIDE_TOOL_INVALID = 0;
   SERVER_SIDE_TOOL_WEB_SEARCH = 1;


### PR DESCRIPTION
Add `ServiceTier` enum to `usage.proto` and `service_tier` field to the chat request, response, and streaming chunk messages.

## Changes

### usage.proto
- New `ServiceTier` enum: `SERVICE_TIER_UNSPECIFIED`, `SERVICE_TIER_DEFAULT`, `SERVICE_TIER_PRIORITY`

### chat.proto
- `GetCompletionsRequest`: added `ServiceTier service_tier = 30`
- `GetChatCompletionResponse`: added `ServiceTier service_tier = 13`
- `GetChatCompletionChunk`: added `ServiceTier service_tier = 11`