### PR TITLE
fix: correct service_tier field numbers + add code-execution output_files

### DIFF
--- a/proto/xai/api/v1/chat.proto
+++ b/proto/xai/api/v1/chat.proto
@@ -178,7 +178,7 @@ message GetCompletionsRequest {
 
   // Processing tier for this request. Set to SERVICE_TIER_PRIORITY for
   // higher scheduling priority at a higher price.
-  ServiceTier service_tier = 30;
+  ServiceTier service_tier = 31;
 }
 
 message GetChatCompletionResponse {
@@ -219,7 +219,7 @@ message GetChatCompletionResponse {
   DebugOutput debug_output = 12;
 
   // The processing tier that was used for this request.
-  ServiceTier service_tier = 13;
+  ServiceTier service_tier = 15;
 }
 
 message GetChatCompletionChunk {
@@ -258,7 +258,7 @@ message GetChatCompletionChunk {
   DebugOutput debug_output = 10;
 
   // The processing tier that was used for this request.
-  ServiceTier service_tier = 11;
+  ServiceTier service_tier = 12;
 }
 
 // Response from GetDeferredCompletion, including the response if the completion

--- a/proto/xai/api/v1/chat.proto
+++ b/proto/xai/api/v1/chat.proto
@@ -218,6 +218,10 @@ message GetChatCompletionResponse {
   // Debug output. Only available to trusted testers.
   DebugOutput debug_output = 12;
 
+  // Files generated during the response (e.g., by the code execution tool).
+  // Only populated when `INCLUDE_OPTION_CODE_EXECUTION_FILES_OUTPUT` is set.
+  repeated OutputFile output_files = 13;
+
   // The processing tier that was used for this request.
   ServiceTier service_tier = 15;
 }
@@ -257,8 +261,21 @@ message GetChatCompletionChunk {
   // Only available for teams that have debugging privileges.
   DebugOutput debug_output = 10;
 
+  // Files generated during the response (e.g., by the code execution tool).
+  // Only populated for the final chunk when `INCLUDE_OPTION_CODE_EXECUTION_FILES_OUTPUT` is set.
+  repeated OutputFile output_files = 11;
+
   // The processing tier that was used for this request.
   ServiceTier service_tier = 12;
+}
+
+// A file generated during a response (e.g., by the code execution tool).
+message OutputFile {
+  // The file ID from the Files API. Use this to download the file.
+  string file_id = 1;
+
+  // The display name of the file.
+  string name = 2;
 }
 
 // Response from GetDeferredCompletion, including the response if the completion
@@ -526,6 +543,9 @@ enum IncludeOption {
   // this option is not included by default.
   // This option is only available for streaming responses.
   INCLUDE_OPTION_VERBOSE_STREAMING = 8;
+
+  // Generated file output from the code execution environment
+  INCLUDE_OPTION_CODE_EXECUTION_FILES_OUTPUT = 9;
 }
 
 // A message in a conversation. This message is part of the model input. Each


### PR DESCRIPTION
Two changes that align the public `chat.proto` with the API.

### 1. Fix `service_tier` field numbers (wire correctness)
`service_tier` was assigned numbers that don't match the API, so a requested tier and the tier reported back were silently dropped on the wire.

| Message | before | after |
|---|---|---|
| `GetCompletionsRequest.service_tier` | 30 | **31** |
| `GetChatCompletionResponse.service_tier` | 13 | **15** |
| `GetChatCompletionChunk.service_tier` | 11 | **12** |

### 2. Add code-execution `output_files`
Expose the generated-files output from the code execution tool:
- `OutputFile` message (`file_id`, `name`)
- `output_files` on `GetChatCompletionResponse` (13) and `GetChatCompletionChunk` (11)
- `INCLUDE_OPTION_CODE_EXECUTION_FILES_OUTPUT` (9) so it can be requested

All field numbers match the API. `buf build` + `buf lint` pass.

xai-sdk-python bindings updated in xai-org/xai-sdk-python#163.