### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: xai-proto-runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # Use paths-filter to check if proto files or this workflow changed
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -30,4 +30,4 @@ jobs:
       # Only run buf checks if proto files or this workflow file changed
       - name: Run Buf Checks
         if: ${{ steps.filter.outputs.proto_changed == 'true' }}
-        uses: bufbuild/buf-action@5150a1eef5c10b6a5cf8a69fc872f24a09473195
+        uses: bufbuild/buf-action@5150a1eef5c10b6a5cf8a69fc872f24a09473195 # v1.1.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       contents: write # Required to create releases
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Fetch all history to ensure tag information is available
 


### PR DESCRIPTION
## Summary

Pin every third-party GitHub Action ref to a full 40-character commit SHA (with a human-readable version comment) so this repository is ready for **org-level** GitHub Actions SHA pin enforcement.

- Format: `uses: owner/action@<40-char-sha> # vX.Y.Z`
- Local actions (`./.github/...`) left unchanged
- Floating refs (`@latest`, `@stable`, `@main`, `@release/*`) pinned to the current tip of that ref

## Why

GitHub setting: **Require actions to be pinned to a full-length commit SHA**. Mutable tags are a supply-chain risk (tag retargeting).

## Test plan

- [ ] CI workflows still run after pin
- [ ] No active remote `uses: owner/action@vN` / `@latest` / `@main` remain

Part of org-wide GitHub Actions hardening across `xai-org`.