### PR TITLE
Add EFFORT_XHIGH to ReasoningEffort enum

### DIFF
--- a/proto/xai/api/v1/chat.proto
+++ b/proto/xai/api/v1/chat.proto
@@ -608,6 +608,7 @@ enum ReasoningEffort {
   EFFORT_MEDIUM = 2;
   EFFORT_HIGH = 3;
   EFFORT_NONE = 4;
+  EFFORT_XHIGH = 5;
 }
 
 // Number of agents to use for multi-agent models.

--- a/proto/xai/api/v1/chat.proto
+++ b/proto/xai/api/v1/chat.proto
@@ -143,7 +143,7 @@ message GetCompletionsRequest {
   // new topics.
   optional float presence_penalty = 9;
 
-  // Constrains effort on reasoning for reasoning models. Default to `EFFORT_MEDIUM`.
+  // Constrains effort on reasoning for reasoning models. Defaults vary by model (e.g. `grok-4.5` and `grok-4.6` default to `EFFORT_HIGH`).
   optional ReasoningEffort reasoning_effort = 19;
 
   // Set the parameters to be used for realtime data. If not set, no realtime data will be acquired by the model.
@@ -1059,7 +1059,7 @@ message RequestSettings {
   // The ID of the previous response from the model.
   optional string previous_response_id = 3;
 
-  // Constrains effort on reasoning for reasoning models. Default to `EFFORT_MEDIUM`.
+  // Constrains effort on reasoning for reasoning models. Defaults vary by model (e.g. `grok-4.5` and `grok-4.6` default to `EFFORT_HIGH`).
   optional ReasoningEffort reasoning_effort = 4;
 
   // A number between 0 and 2 used to control the variance of completions.


### PR DESCRIPTION
# Changes
- Add `EFFORT_XHIGH = 5` to the `ReasoningEffort` enum in `chat.proto`, matching the value already served by the API (`reasoning_effort=xhigh`, supported by models such as `grok-4.6`).
- Clarify the `reasoning_effort` field comments: the default varies by model (e.g. `grok-4.5` and `grok-4.6` default to `EFFORT_HIGH`) rather than always being `EFFORT_MEDIUM`.

Same shape as #49 (which added `EFFORT_NONE`). Companion SDK change: xai-org/xai-sdk-python#189 adds the `"xhigh"` literal and regenerated stubs.