### PR TITLE
Add file storage, public URL, and file-ID input proto fields

### DIFF
--- a/proto/xai/api/v1/files.proto
+++ b/proto/xai/api/v1/files.proto
@@ -35,6 +35,45 @@ service Files {
   // Stream the file's contents in chunks of up to 5 MB, in order.
   // Concatenate `data` from every chunk to reconstruct the file.
   rpc RetrieveFileContent(RetrieveFileContentRequest) returns (stream FileContentChunk) {}
+
+  // Create a public, unauthenticated URL for a file, accessible without an
+  // API key. Only images, videos, and PDFs can be made public.
+  //
+  // A file can have at most one public URL at a time. Calling this on a
+  // file that already has a public URL returns the existing URL. To update
+  // the expiry, call again with a new `expires_after` value.
+  //
+  // **Public URL expiry behavior:**
+  //
+  // - If `expires_after` is set, the public URL expires that many seconds
+  //   from now, independently of the file's own TTL.
+  // - If `expires_after` is omitted and the file has a TTL
+  //   (`UploadFileInit.expires_after` was set at upload), the public URL
+  //   automatically inherits the file's expiry — it will expire at the
+  //   same time as the file.
+  // - If `expires_after` is omitted and the file has no TTL, the public
+  //   URL remains valid indefinitely (until explicitly revoked or the file
+  //   is deleted).
+  //
+  // **Automatic revocation:**
+  //
+  // A public URL is automatically revoked when the file is deleted (by the
+  // user or by TTL expiry). Revocation may not take effect immediately, so
+  // the URL can remain accessible for a short period after the file or the
+  // public URL expires. Call `RevokePublicUrl` to revoke immediately.
+  rpc CreatePublicUrl(CreatePublicUrlRequest) returns (CreatePublicUrlResponse) {}
+
+  // Revoke the public URL for a file. After revocation the public URL is
+  // no longer accessible, while the original file remains accessible via
+  // authenticated endpoints.
+  //
+  // Public URLs are also automatically revoked when the file is deleted,
+  // when the file's TTL elapses, or when the public URL's own expiry
+  // elapses. Automatic revocation may not take effect immediately; use this
+  // RPC to revoke a public URL right away.
+  //
+  // Returns success if the file has no public URL (nothing to revoke).
+  rpc RevokePublicUrl(RevokePublicUrlRequest) returns (RevokePublicUrlResponse) {}
 }
 
 // First stream message of an `UploadFile` call. Sent exactly once, before
@@ -83,6 +122,14 @@ message File {
   string id = 5;
 
   reserved 6;
+
+  // Public URL for the file. Only present when the file has an active
+  // public URL (created via CreatePublicUrl or storage_options.public_url).
+  optional string public_url = 7;
+
+  // When the public URL expires. Only present when public_url is set
+  // and has an independent expiry.
+  optional google.protobuf.Timestamp public_url_expires_at = 8;
 }
 
 // Sort direction for list-style RPCs.
@@ -118,6 +165,16 @@ message ListFilesRequest {
 
   // Sort field. Defaults to `FILES_SORT_BY_CREATED_AT`.
   optional FilesSortBy sort_by = 4;
+
+  // AIP-160 filter expression to narrow down results.
+  // Supported fields: file_id, name (or file_name), size_bytes,
+  // content_type, created_at, expires_at, upload_status, user_defined_id.
+  // Operators: =, !=, >, >=, <, <=, AND, OR, NOT.
+  // Examples:
+  //   - 'name:"report"'
+  //   - 'content_type = "application/pdf"'
+  //   - 'size_bytes > 1000000 AND created_at > "2024-01-01T00:00:00Z"'
+  optional string filter = 5;
 }
 
 // Response message for `Files.ListFiles`.
@@ -177,4 +234,49 @@ message RetrieveFileContentRequest {
 message FileContentChunk {
   // Up to 5 MB of file bytes. Final/intermediate chunks may be smaller.
   bytes data = 1;
+}
+
+// Request message for `Files.CreatePublicUrl`.
+message CreatePublicUrlRequest {
+  // The ID of the file to create a public URL for.
+  string file_id = 1;
+
+  // Seconds from now until the public URL expires. Must be between 3600
+  // (1 hour) and 2592000 (30 days).
+  //
+  // If omitted and the file has a TTL, the public URL inherits the file's
+  // expiry. If omitted and the file has no TTL, the public URL remains
+  // valid indefinitely until the file is deleted or the URL is explicitly
+  // revoked via `RevokePublicUrl`.
+  optional int64 expires_after = 2;
+}
+
+// Response message for `Files.CreatePublicUrl`.
+message CreatePublicUrlResponse {
+  // The full public URL that can be shared and accessed without an API key.
+  string public_url = 1;
+
+  // When the public URL expires. Present when the public URL has an expiry,
+  // either from an explicit `expires_after` in the request or inherited from
+  // the file's TTL. Absent when the public URL is valid indefinitely.
+  optional google.protobuf.Timestamp expires_at = 2;
+}
+
+// Request message for `Files.RevokePublicUrl`.
+message RevokePublicUrlRequest {
+  // The ID of the file whose public URL should be revoked.
+  string file_id = 1;
+}
+
+// Response message for `Files.RevokePublicUrl`.
+message RevokePublicUrlResponse {
+  // The file ID whose public URL was revoked.
+  string file_id = 1;
+
+  // True if a public URL was actually revoked. False if the file had
+  // no active public URL (no-op).
+  bool revoked = 2;
+
+  // The full public URL that was revoked. Only present when revoked is true.
+  optional string public_url = 3;
 }

--- a/proto/xai/api/v1/image.proto
+++ b/proto/xai/api/v1/image.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package xai_api;
 
+import "google/protobuf/timestamp.proto";
 import "xai/api/v1/usage.proto";
 
 // An API service for interaction with image generation models.
@@ -53,6 +54,62 @@ message GenerateImageRequest {
   // Each image is either an image URL or a base64-encoded version of the image.
   // This field cannot be set together with the `image` field.
   repeated ImageUrlContent images = 17;
+
+  // Optional output storage configuration. When present, the generated
+  // image(s) are stored in the Files API and a file_id is returned in
+  // the response alongside the ephemeral URL.
+  optional StorageOptions storage_options = 19;
+}
+
+// Configuration for storing generation output in the Files API.
+message StorageOptions {
+  // Filename for the stored file.
+  string filename = 1;
+  // Seconds from now until the file auto-expires. If omitted, the file
+  // does not expire.
+  optional int64 expires_after = 2;
+  // When present, a public URL is created for the stored file after upload.
+  // The public URL is accessible without authentication.
+  // Omit entirely to store the file privately (no public URL).
+  optional PublicUrlOptions public_url = 3;
+}
+
+// Configuration for creating a public URL alongside file storage.
+message PublicUrlOptions {
+  // Seconds from now until the public URL expires.
+  //
+  // If omitted and the file has a TTL (`StorageOptions.expires_after`),
+  // the public URL inherits the file's expiry. If omitted and the file
+  // has no TTL, the public URL remains valid indefinitely until the file
+  // is deleted or the URL is explicitly revoked via `RevokePublicUrl`.
+  // The file itself always remains accessible via authenticated endpoints
+  // after the public URL expires.
+  optional int64 expires_after = 1;
+}
+
+// Information about a generated file stored in the Files API.
+message FileOutput {
+  // Files API file_id of the stored file.
+  string file_id = 1;
+  // Filename of the stored file.
+  string filename = 2;
+  reserved 3;
+  // Public URL for the stored file. Only present when the request included
+  // storage_options.public_url and creation succeeded.
+  optional string public_url = 4;
+  // When the public URL expires. Only present when public_url is set and
+  // has an independent expiry (i.e. the request specified
+  // public_url.expires_after, or the file has a TTL). Absent when the
+  // public URL is valid indefinitely.
+  optional google.protobuf.Timestamp public_url_expires_at = 5;
+  // When the stored file expires and will be automatically deleted. Only
+  // present when the file has an expiration (storage_options.expires_after
+  // was set).
+  optional google.protobuf.Timestamp expires_at = 6;
+  // Human-readable error when storage_options.public_url was set but
+  // public URL creation failed. The file itself was stored successfully —
+  // the public URL can be retried via `CreatePublicUrl`.
+  optional string public_url_error = 7;
 }
 
 // The response from the image generation models containing the generated image(s).
@@ -86,18 +143,35 @@ message GeneratedImage {
   // The field will be true if the image respect moderation rules. Otherwise
   // the field will be false and the image field is replaced by a placeholder.
   bool respect_moderation = 4;
+
+  // Storage info for the generated image. Only present when the request
+  // included `storage_options` and the upload succeeded.
+  optional FileOutput file_output = 8;
+
+  // Human-readable error when `storage_options` was set but the upload
+  // failed. Only present on storage failure; absent on success or when
+  // storage was not requested.
+  optional string storage_error = 9;
 }
 
 // Contains data relating to an image that is provided to the model.
 message ImageUrlContent {
-  // This is either an image URL or a base64-encoded version of the image.
-  // The following image formats are supported: PNG, JPG, and WebP.
-  // If an image URL is provided, the image will be downloaded for every API
-  // request without being cached. Images are fetched using
-  // "XaiImageApiFetch/1.0" user agent, and will timeout after 5 seconds.
-  // The image size is limited to 10 MiB. If the image download fails, the API
-  // request will fail as well.
-  string image_url = 1;
+  // The source of the image — either a direct URL/base64 string or a
+  // file_id from the xAI Files API. Exactly one must be set.
+  oneof source {
+    // This is either an image URL or a base64-encoded version of the image.
+    // The following image formats are supported: PNG, JPG, and WebP.
+    // If an image URL is provided, the image will be downloaded for every API
+    // request without being cached. Images are fetched using
+    // "XaiImageApiFetch/1.0" user agent, and will timeout after 5 seconds.
+    // The image size is limited to 10 MiB. If the image download fails, the API
+    // request will fail as well.
+    string image_url = 1;
+
+    // A file ID from the xAI Files API. The file must be an image
+    // (JPEG, PNG, or WebP).
+    string file_id = 3;
+  }
 
   // The level of pre-processing resolution that will be applied to the image.
   ImageDetail detail = 2;

--- a/proto/xai/api/v1/video.proto
+++ b/proto/xai/api/v1/video.proto
@@ -47,11 +47,19 @@ enum VideoResolution {
   VIDEO_RESOLUTION_720P = 2;
 }
 
-// Specifies a video by URL for video editing.
+// Specifies a video by URL or file reference for video editing.
 message VideoUrlContent {
-  // Either a URL of the video (e.g., a public URL) or a base64-encoded video
-  // as a data URL (e.g., "data:video/mp4;base64,...").
-  string url = 1;
+  // The source of the video — either a direct URL/base64 string or a
+  // file_id from the xAI Files API. Exactly one must be set.
+  oneof source {
+    // Either a URL of the video (e.g., a public URL) or a base64-encoded video
+    // as a data URL (e.g., "data:video/mp4;base64,...").
+    string url = 1;
+
+    // A file ID from the xAI Files API. The file must be a video
+    // (e.g., MP4).
+    string file_id = 2;
+  }
 }
 
 // An API service for interaction with video generation models.
@@ -110,6 +118,11 @@ message GenerateVideoRequest {
   // When provided (and `image` is not set), generates video using these images
   // as style/content references.
   repeated ImageUrlContent reference_images = 13;
+
+  // Optional output storage configuration. When present, the generated
+  // video is stored in the Files API and a file_id is returned in
+  // the response alongside the ephemeral URL.
+  optional StorageOptions storage_options = 14;
 }
 
 // Request for retrieving deferred video generation results.
@@ -154,6 +167,15 @@ message GeneratedVideo {
   // The field will be true if the video respects moderation rules. Otherwise
   // the field will be false and the video url field will be empty.
   bool respect_moderation = 5;
+
+  // Storage info for the generated video. Only present when the request
+  // included `storage_options` and the upload succeeded.
+  optional FileOutput file_output = 6;
+
+  // Human-readable error when `storage_options` was set but the upload
+  // failed. Only present on storage failure; absent on success or when
+  // storage was not requested.
+  optional string storage_error = 7;
 }
 
 // Response from GetDeferredVideo, including the response if the video
@@ -191,4 +213,9 @@ message ExtendVideoRequest {
   // Duration of the extension segment to generate in seconds (1-10).
   // Defaults to 6 seconds if not specified.
   optional int32 duration = 4;
+
+  // Optional output storage configuration. When present, the generated
+  // video is stored in the Files API and a file_id is returned in
+  // the response alongside the ephemeral URL.
+  optional StorageOptions storage_options = 6;
 }


### PR DESCRIPTION
Add file storage, public URL, and file-ID input proto fields

Catches proto/ up with fields that already ship in the published Python
SDK (xai-sdk-python v1.16.0) but were never declared here.

**files.proto**
- `CreatePublicUrl` / `RevokePublicUrl` RPCs with request/response messages
- `File.public_url` and `File.public_url_expires_at`
- `ListFilesRequest.filter` — AIP-160 filter expression

**image.proto**
- `StorageOptions`, `PublicUrlOptions`, and `FileOutput` messages
- `GenerateImageRequest.storage_options`
- `GeneratedImage.file_output` and `storage_error`
- `ImageUrlContent`: move `image_url` into a `oneof source` and add
  `file_id` as an alternative input

**video.proto**
- `VideoUrlContent`: move `url` into a `oneof source` and add `file_id`
  as an alternative input
- `storage_options` on `GenerateVideoRequest` and `ExtendVideoRequest`
- `GeneratedVideo.file_output` and `storage_error`

**Wire compatibility**: everything is additive, existing field numbers and
types are unchanged. `buf breaking` flags the two oneof moves, but they
are wire-compatible and match the generated code the SDK has shipped
since v1.16.0.